### PR TITLE
fix: Correct typo in Jest config key from moduleNameMapping to moduleNameMapper

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ export default {
     'app/**/*.ts',
     '!app/**/*.d.ts',
   ],
-  moduleNameMapping: {
+  moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
 };


### PR DESCRIPTION
**What:**
Fixed a configuration typo in jest.config.js — changed moduleNameMapping to the correct key moduleNameMapper.

**Why:**
Jest was throwing a validation warning due to the use of an incorrect config key.
This typo (moduleNameMapping instead of moduleNameMapper) was introduced by mistake and caused Jest to ignore module alias mappings, potentially affecting module resolution during tests.

**Before:**
<img width="638" height="558" alt="Screenshot 2025-07-24 at 3 03 10 AM" src="https://github.com/user-attachments/assets/37e5dee9-0ef4-4335-a180-8937676d0f9d" />


**After:**
<img width="638" height="475" alt="Screenshot 2025-07-24 at 3 03 59 AM" src="https://github.com/user-attachments/assets/df120d31-6e48-4b2e-9fbf-9e226e6064e6" />
