### PR TITLE
feat: Add dedicated repository management page and improve auth UX

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -78,7 +78,7 @@ export async function GET(request: NextRequest) {
     const userData = await userResponse.json();
 
     // Create response and set secure cookies
-    const response = NextResponse.redirect(new URL("/", request.url));
+    const response = NextResponse.redirect(new URL("/repository", request.url));
 
     // Set secure cookies
     response.cookies.set("github_access_token", tokenData.access_token, {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,11 +5,10 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Github } from "lucide-react";
 import { GithubCommentDemo } from "@/components/github-comment-demo";
-import { RepositorySettings } from "@/components/repository-settings";
 import { useAuth } from "@/lib/auth";
 
 export default function JacquezLandingPage() {
-  const { user, isAuthenticated } = useAuth();
+  const { isAuthenticated, loading } = useAuth();
 
   const handleLogout = async () => {
     try {
@@ -52,7 +51,12 @@ export default function JacquezLandingPage() {
                 </p>
               </div>
               <div className="flex flex-col gap-2 min-[400px]:flex-row">
-                {!isAuthenticated ? (
+                {loading ? (
+                  <div className="flex items-center">
+                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-gray-900 dark:border-white mr-2"></div>
+                    <span className="text-sm">Loading...</span>
+                  </div>
+                ) : !isAuthenticated ? (
                   <Button
                     asChild
                     size="lg"
@@ -64,23 +68,30 @@ export default function JacquezLandingPage() {
                     </Link>
                   </Button>
                 ) : (
-                  <Button
-                    onClick={handleLogout}
-                    size="lg"
-                    className="bg-black dark:bg-white text-white dark:text-black hover:bg-black/90 dark:hover:bg-white/90"
-                  >
-                    Logout
-                  </Button>
+                  <div className="flex flex-col gap-2 min-[400px]:flex-row">
+                    <Button
+                      asChild
+                      size="lg"
+                      className="bg-black dark:bg-white text-white dark:text-black hover:bg-black/90 dark:hover:bg-white/90"
+                    >
+                      <Link href="/repository" prefetch={false}>
+                        Manage Repositories
+                      </Link>
+                    </Button>
+                    <Button
+                      onClick={handleLogout}
+                      size="lg"
+                      variant="outline"
+                    >
+                      Logout
+                    </Button>
+                  </div>
                 )}
               </div>
             </div>
             <div className="flex items-center justify-center">
               <Card className="bg-white dark:bg-black p-6 w-full max-w-none md:max-w-2xl md:mx-auto shadow-none md:shadow-lg rounded-none md:rounded-lg border-x-0 md:border-x">
-                {isAuthenticated ? (
-                  <RepositorySettings />
-                ) : (
-                  <GithubCommentDemo />
-                )}
+                <GithubCommentDemo />
               </Card>
             </div>
           </div>

--- a/app/repository/page.tsx
+++ b/app/repository/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { RepositorySettings } from "@/components/repository-settings";
+import { useAuth } from "@/lib/auth";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function RepositoryPage() {
+    const { isAuthenticated, loading } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (!loading && !isAuthenticated) {
+            router.push("/");
+        }
+    }, [isAuthenticated, loading, router]);
+
+    const handleLogout = async () => {
+        try {
+            await fetch("/api/auth/logout", {
+                method: "POST",
+            });
+            window.location.href = "/";
+        } catch (err) {
+            console.error("Logout failed:", err);
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="flex flex-col min-h-dvh bg-gray-100 dark:bg-black text-black dark:text-white">
+                <div className="flex items-center justify-center flex-1">
+                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 dark:border-white"></div>
+                </div>
+            </div>
+        );
+    }
+
+    if (!isAuthenticated) {
+        return null; // Will redirect via useEffect
+    }
+
+    return (
+        <div className="flex flex-col min-h-dvh bg-gray-100 dark:bg-black text-black dark:text-white">
+            <header className="border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-black">
+                <div className="container mx-auto px-6 py-4">
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center space-x-4">
+                            <Button variant="ghost" size="sm" asChild>
+                                <Link href="/">
+                                    <ArrowLeft className="h-4 w-4 mr-2" />
+                                    Back to Home
+                                </Link>
+                            </Button>
+                            <div className="flex items-center space-x-2">
+                                <svg
+                                    width="32"
+                                    height="32"
+                                    viewBox="0 0 32 32"
+                                    fill="none"
+                                    aria-hidden="true"
+                                    className="inline-block"
+                                >
+                                    <polygon points="4,28 28,28 28,4" fill="currentColor" />
+                                </svg>
+                                <h1 className="text-xl font-semibold">Jacquez</h1>
+                            </div>
+                        </div>
+                        <Button onClick={handleLogout} variant="outline" size="sm">
+                            Logout
+                        </Button>
+                    </div>
+                </div>
+            </header>
+
+            <main className="flex-1 container mx-auto px-6 py-8">
+                <div className="max-w-4xl mx-auto">
+                    <RepositorySettings />
+                </div>
+            </main>
+        </div>
+    );
+}


### PR DESCRIPTION
Fix: #37 

### Why:
- Separates concerns: Landing page stays focused on marketing/demo, repository management gets its own dedicated space
- Eliminates content flashing: No more jarring switches between landing content and repository settings
- Better UX patterns: Follows standard web app conventions with dedicated pages for different functionality
- Enhanced routing: Users can bookmark, share, and navigate directly to repository management

### Changes included:
- Created /repository page for authenticated repository management
- Updated landing page to show consistent content with proper auth state handling
- Improved button layout and user flow for authenticated vs non-authenticated states

Before:

https://github.com/user-attachments/assets/98269cde-ad88-4627-babb-9ff7aef641f7

After:


https://github.com/user-attachments/assets/b419e0ce-1c48-41d6-af12-ea5b83ecdac2

