### PR TITLE
Fixes Issue #51 Implement Jacquez GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,48 @@
+name: 'Jacquez - Contributing Guidelines Enforcer'
+description: 'A GitHub Action that enforces contributing guidelines on Pull Requests'
+author: 'antiwork'
+
+branding:
+  icon: 'shield'
+  color: 'blue'
+
+inputs:
+  github-token:
+    description: 'GitHub token for API access'
+    required: true
+    default: ${{ github.token }}
+  anthropic-api-key:
+    description: 'Anthropic API key for AI analysis'
+    required: true
+  ai-model:
+    description: 'AI model to use for analysis'
+    required: false
+    default: 'claude-sonnet-4-20250514'
+  max-tokens:
+    description: 'Maximum tokens for AI response'
+    required: false
+    default: '300'
+  enable-detailed-logging:
+    description: 'Enable detailed logging'
+    required: false
+    default: 'false'
+  fail-on-violations:
+    description: 'Whether to fail the action when violations are found'
+    required: false
+    default: 'true'
+  skip-drafts:
+    description: 'Skip analysis for draft PRs'
+    required: false
+    default: 'true'
+
+outputs:
+  violations-found:
+    description: 'Whether any violations were found'
+  violation-count:
+    description: 'Number of violations found'
+  analysis-summary:
+    description: 'Summary of the analysis results'
+
+runs:
+  using: 'node20'
+  main: 'dist/action.js'

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:action": "tsc --project tsconfig.action.json && cp -r utils dist/ && cp package.json dist/",
+    "test:action": "npm run build:action && node test-action-build.js",
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
@@ -25,6 +27,8 @@
   },
   "homepage": "https://github.com/antiwork/jacquez#readme",
   "dependencies": {
+    "@actions/core": "^1.11.1",
+    "@actions/github": "^6.0.1",
     "@anthropic-ai/sdk": "^0.56.0",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-slot": "^1.2.3",

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+import { Octokit } from 'octokit'
+import Anthropic from '@anthropic-ai/sdk'
+import { loadContributingGuidelines } from './lib/contributing'
+import { analyzePullRequest } from './lib/pr-analyzer'
+import { createCheckRun } from './lib/check-run'
+
+interface ActionConfig {
+  githubToken: string
+  anthropicApiKey: string
+  aiModel: string
+  maxTokens: number
+  enableDetailedLogging: boolean
+  failOnViolations: boolean
+  skipDrafts: boolean
+}
+
+interface AnalysisResult {
+  violationsFound: boolean
+  violationCount: number
+  summary: string
+  details: Array<{
+    file: string
+    line: number
+    message: string
+    severity: 'error' | 'warning'
+  }>
+}
+
+function getConfig(): ActionConfig {
+  return {
+    githubToken: core.getInput('github-token', { required: true }),
+    anthropicApiKey: core.getInput('anthropic-api-key', { required: true }),
+    aiModel: core.getInput('ai-model') || 'claude-sonnet-4-20250514',
+    maxTokens: parseInt(core.getInput('max-tokens') || '300'),
+    enableDetailedLogging: core.getInput('enable-detailed-logging') === 'true',
+    failOnViolations: core.getInput('fail-on-violations') === 'true',
+    skipDrafts: core.getInput('skip-drafts') === 'true',
+  }
+}
+
+function log(level: string, message: string, data?: any) {
+  const timestamp = new Date().toISOString()
+  const logMessage = `[${timestamp}] ${level}: ${message}`
+  
+  if (data) {
+    console.log(`${logMessage}\n${JSON.stringify(data, null, 2)}`)
+  } else {
+    console.log(logMessage)
+  }
+
+  switch (level) {
+    case 'ERROR':
+      core.error(message)
+      break
+    case 'WARN':
+      core.warning(message)
+      break
+    case 'INFO':
+      core.info(message)
+      break
+    default:
+      core.debug(message)
+  }
+}
+
+async function run(): Promise<void> {
+  try {
+    const config = getConfig()
+    const context = github.context
+
+    log('INFO', 'Starting Jacquez PR analysis', {
+      repo: context.repo,
+      pr: context.payload.pull_request?.number,
+      action: context.eventName
+    })
+
+    if (!context.payload.pull_request) {
+      core.setFailed('This action can only be run on pull_request events')
+      return
+    }
+
+    const pr = context.payload.pull_request
+    const { owner, repo } = context.repo
+
+    if (config.skipDrafts && pr.draft) {
+      log('INFO', 'Skipping draft PR analysis')
+      core.setOutput('violations-found', 'false')
+      core.setOutput('violation-count', '0')
+      core.setOutput('analysis-summary', 'Skipped: Draft PR')
+      return
+    }
+
+    if (pr.user.type === 'Bot') {
+      log('INFO', 'Skipping bot PR analysis')
+      core.setOutput('violations-found', 'false')
+      core.setOutput('violation-count', '0')
+      core.setOutput('analysis-summary', 'Skipped: Bot PR')
+      return
+    }
+
+    const octokit = new Octokit({ auth: config.githubToken })
+    const anthropic = new Anthropic({ apiKey: config.anthropicApiKey })
+
+    const contributingContent = await loadContributingGuidelines(octokit, owner, repo)
+    
+    if (!contributingContent) {
+      log('WARN', 'No contributing guidelines found, skipping analysis')
+      core.setOutput('violations-found', 'false')
+      core.setOutput('violation-count', '0')
+      core.setOutput('analysis-summary', 'Skipped: No contributing guidelines found')
+      return
+    }
+
+    const analysisResult: AnalysisResult = await analyzePullRequest({
+      octokit,
+      anthropic,
+      owner,
+      repo,
+      prNumber: pr.number,
+      prBody: pr.body || '',
+      contributingContent,
+      config
+    })
+
+    await createCheckRun({
+      octokit,
+      owner,
+      repo,
+      headSha: pr.head.sha,
+      analysisResult
+    })
+
+    core.setOutput('violations-found', analysisResult.violationsFound.toString())
+    core.setOutput('violation-count', analysisResult.violationCount.toString())
+    core.setOutput('analysis-summary', analysisResult.summary)
+
+    if (analysisResult.violationsFound && config.failOnViolations) {
+      core.setFailed(
+        `Found ${analysisResult.violationCount} contributing guideline violation(s). ` +
+        `See the check run for details.`
+      )
+    } else if (analysisResult.violationsFound) {
+      core.warning(
+        `Found ${analysisResult.violationCount} contributing guideline violation(s), ` +
+        `but not failing due to configuration.`
+      )
+    } else {
+      log('INFO', 'No violations found, PR follows contributing guidelines!')
+    }
+
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    const errorStack = error instanceof Error ? error.stack : undefined
+    
+    log('ERROR', 'Action failed', { error: errorMessage, stack: errorStack })
+    core.setFailed(`Action failed: ${errorMessage}`)
+  }
+}
+
+run()

--- a/src/lib/check-run.ts
+++ b/src/lib/check-run.ts
@@ -1,0 +1,96 @@
+import { Octokit } from 'octokit'
+
+interface AnalysisResult {
+  violationsFound: boolean
+  violationCount: number
+  summary: string
+  details: Array<{
+    file: string
+    line: number
+    message: string
+    severity: 'error' | 'warning'
+  }>
+}
+
+interface CheckRunParams {
+  octokit: Octokit
+  owner: string
+  repo: string
+  headSha: string
+  analysisResult: AnalysisResult
+}
+
+export async function createCheckRun({
+  octokit,
+  owner,
+  repo,
+  headSha,
+  analysisResult
+}: CheckRunParams): Promise<void> {
+  try {
+    const checkName = 'Jacquez - Contributing Guidelines'
+    const conclusion = analysisResult.violationsFound ? 'failure' : 'success'
+    const title = analysisResult.violationsFound 
+      ? `${analysisResult.violationCount} violation(s) found`
+      : 'No violations found'
+
+    let summary = `## ${analysisResult.summary}\n\n`
+    
+    if (analysisResult.violationsFound) {
+      summary += `Found ${analysisResult.violationCount} contributing guideline violation(s):\n\n`
+      
+      const violationsByFile = analysisResult.details.reduce((acc, detail) => {
+        if (!acc[detail.file]) {
+          acc[detail.file] = []
+        }
+        acc[detail.file].push(detail)
+        return acc
+      }, {} as Record<string, typeof analysisResult.details>)
+
+      for (const [file, violations] of Object.entries(violationsByFile)) {
+        summary += `### ${file}\n\n`
+        violations.forEach((violation, index) => {
+          const icon = violation.severity === 'error' ? '❌' : '⚠️'
+          const lineInfo = violation.line > 0 ? `Line ${violation.line}` : ''
+          summary += `${icon} **${lineInfo}**: ${violation.message}\n\n`
+        })
+      }
+
+      summary += `\n---\n\n`
+      summary += `Please review the violations above and update your PR to follow the contributing guidelines.`
+    } else {
+      summary += `✅ This PR follows all contributing guidelines. Great work!`
+    }
+
+    const annotations = analysisResult.details
+      .filter(detail => detail.line > 0 && detail.file !== 'PR Description')
+      .map(detail => ({
+        path: detail.file,
+        start_line: detail.line,
+        end_line: detail.line,
+        annotation_level: (detail.severity === 'error' ? 'failure' : 'warning') as 'failure' | 'warning' | 'notice',
+        message: detail.message,
+        title: 'Contributing Guideline Violation'
+      }))
+
+    await octokit.request('POST /repos/{owner}/{repo}/check-runs', {
+      owner,
+      repo,
+      name: checkName,
+      head_sha: headSha,
+      status: 'completed',
+      conclusion,
+      output: {
+        title,
+        summary,
+        annotations: annotations.slice(0, 50) 
+      }
+    })
+
+    console.log(`Check run created: ${conclusion} with ${annotations.length} annotations`)
+
+  } catch (error: any) {
+    console.error('Error creating check run:', error.message)
+    throw error
+  }
+}

--- a/src/lib/contributing.ts
+++ b/src/lib/contributing.ts
@@ -1,0 +1,61 @@
+import { Octokit } from 'octokit'
+
+const cache = new Map<string, { content: string; timestamp: number }>()
+const CACHE_TIMEOUT = 300000
+
+export async function loadContributingGuidelines(
+  octokit: Octokit,
+  owner: string,
+  repo: string
+): Promise<string | null> {
+  const cacheKey = `${owner}/${repo}`
+
+  if (cache.has(cacheKey)) {
+    const cached = cache.get(cacheKey)!
+    if (Date.now() - cached.timestamp < CACHE_TIMEOUT) {
+      console.log(`Contributing guidelines loaded from cache for ${cacheKey}`)
+      return cached.content
+    } else {
+      cache.delete(cacheKey) 
+    }
+  }
+
+  console.log(`Loading contributing guidelines for ${cacheKey}`)
+
+  const altPaths = [
+    'CONTRIBUTING.md',
+    'contributing.md',
+    '.github/CONTRIBUTING.md',
+    'docs/CONTRIBUTING.md',
+  ]
+
+  for (const path of altPaths) {
+    try {
+      const response = await octokit.request(
+        'GET /repos/{owner}/{repo}/contents/{path}',
+        {
+          owner,
+          repo,
+          path,
+        }
+      )
+
+      if (response.data && 'content' in response.data && response.data.content) {
+        const content = Buffer.from(response.data.content, 'base64').toString('utf-8')
+
+        cache.set(cacheKey, {
+          content,
+          timestamp: Date.now(),
+        })
+
+        console.log(`Contributing guidelines found at ${path} for ${cacheKey}`)
+        return content
+      }
+    } catch (error: any) {
+      console.log(`Failed to load contributing guidelines from ${path}: ${error.message}`)
+    }
+  }
+
+  console.log(`No contributing guidelines found for ${cacheKey}`)
+  return null
+}

--- a/src/lib/json-parser.ts
+++ b/src/lib/json-parser.ts
@@ -1,0 +1,48 @@
+import { jsonrepair } from 'jsonrepair'
+
+export interface AIResponse {
+  comment_needed: boolean
+  comment: string
+  reasoning: string
+}
+
+export function parseAIResponse(aiResponse: string): AIResponse {
+  try {
+    const fullJsonResponse = "{" + aiResponse
+    const parsedResponse = JSON.parse(fullJsonResponse)
+    
+    return {
+      comment_needed: parsedResponse.comment_needed || false,
+      comment: parsedResponse.comment || "",
+      reasoning: parsedResponse.reasoning || "",
+    }
+  } catch (parseError) {
+    try {
+      const fullJsonResponse = "{" + aiResponse
+      const repairedJson = jsonrepair(fullJsonResponse)
+      const parsedResponse = JSON.parse(repairedJson)
+      
+      if (parsedResponse.hasOwnProperty('comment_needed') || 
+          parsedResponse.hasOwnProperty('comment') || 
+          parsedResponse.hasOwnProperty('reasoning')) {
+        return {
+          comment_needed: parsedResponse.comment_needed || false,
+          comment: parsedResponse.comment || "",
+          reasoning: parsedResponse.reasoning || "Repaired from malformed JSON response",
+        }
+      } else {
+        return {
+          comment_needed: false,
+          comment: "",
+          reasoning: "Failed to parse JSON response, skipping comment to avoid posting malformed content",
+        }
+      }
+    } catch (repairError) {
+      return {
+        comment_needed: false,
+        comment: "",
+        reasoning: "Failed to parse JSON response, skipping comment to avoid posting malformed content",
+      }
+    }
+  }
+}

--- a/src/lib/pr-analyzer.ts
+++ b/src/lib/pr-analyzer.ts
@@ -1,0 +1,370 @@
+import { Octokit } from 'octokit'
+import Anthropic from '@anthropic-ai/sdk'
+import { parseAIResponse } from './json-parser'
+
+interface PRAnalysisConfig {
+  aiModel: string
+  maxTokens: number
+  enableDetailedLogging: boolean
+}
+
+interface PRAnalysisParams {
+  octokit: Octokit
+  anthropic: Anthropic
+  owner: string
+  repo: string
+  prNumber: number
+  prBody: string
+  contributingContent: string
+  config: PRAnalysisConfig
+}
+
+interface AnalysisResult {
+  violationsFound: boolean
+  violationCount: number
+  summary: string
+  details: Array<{
+    file: string
+    line: number
+    message: string
+    severity: 'error' | 'warning'
+  }>
+}
+
+export async function analyzePullRequest(params: PRAnalysisParams): Promise<AnalysisResult> {
+  const { octokit, anthropic, owner, repo, prNumber, prBody, contributingContent, config } = params
+
+  const result: AnalysisResult = {
+    violationsFound: false,
+    violationCount: 0,
+    summary: '',
+    details: []
+  }
+
+  try {
+    const descriptionAnalysis = await analyzePRDescription({
+      prBody,
+      contributingContent,
+      anthropic,
+      config
+    })
+
+    if (descriptionAnalysis.comment_needed) {
+      result.violationsFound = true
+      result.violationCount++
+      result.details.push({
+        file: 'PR Description',
+        line: 0,
+        message: descriptionAnalysis.comment,
+        severity: 'error'
+      })
+    }
+
+    const codeAnalysis = await analyzePRCode({
+      octokit,
+      owner,
+      repo,
+      prNumber,
+      contributingContent,
+      anthropic,
+      config
+    })
+
+    result.violationCount += codeAnalysis.violationCount
+    if (codeAnalysis.violationCount > 0) {
+      result.violationsFound = true
+      result.details.push(...codeAnalysis.details)
+    }
+
+    if (result.violationsFound) {
+      result.summary = `Found ${result.violationCount} violation(s) in this PR`
+    } else {
+      result.summary = 'No contributing guideline violations found'
+    }
+
+    return result
+
+  } catch (error: any) {
+    console.error('Error analyzing pull request:', error.message)
+    result.summary = 'Error occurred during analysis'
+    return result
+  }
+}
+
+async function analyzePRDescription({
+  prBody,
+  contributingContent,
+  anthropic,
+  config
+}: {
+  prBody: string
+  contributingContent: string
+  anthropic: Anthropic
+  config: PRAnalysisConfig
+}): Promise<{ comment_needed: boolean; comment: string; reasoning: string }> {
+  
+  if (!prBody.trim()) {
+    return {
+      comment_needed: true,
+      comment: 'This PR is missing a description. Please add a description explaining what changes were made and why.',
+      reasoning: 'Empty PR description'
+    }
+  }
+
+  if (prBody.toLowerCase().includes('aside')) {
+    return {
+      comment_needed: false,
+      comment: '',
+      reasoning: 'Skipped due to aside keyword'
+    }
+  }
+
+  try {
+    const systemPrompt = `You are a GitHub bot that enforces contributing guidelines. Only comment when there are clear, specific violations of the contributing guidelines.
+
+DO NOT comment for:
+- Minor style, grammar, or formatting issues
+- Casual but professional language
+- Submissions that mostly follow guidelines
+
+Response format (JSON):
+- comment_needed: boolean (true only for clear violations)
+- comment: string (1-2 sentences max, direct and actionable)
+- reasoning: string (brief explanation)
+
+If commenting, be direct and specific about what's missing without patronizing language.`
+
+    const messages: Anthropic.Messages.MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `Contributing guidelines:\n${contributingContent}`,
+            cache_control: { type: 'ephemeral' },
+          },
+          {
+            type: 'text',
+            text: `Submission type: pull request
+Submission content:
+${prBody}`,
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: '{',
+      },
+    ]
+
+    const response = await anthropic.messages.create({
+      model: config.aiModel,
+      max_tokens: config.maxTokens,
+      system: systemPrompt,
+      messages: messages,
+    })
+
+    const aiResponse = response.content[0].type === 'text' ? response.content[0].text : ''
+    return parseAIResponse(aiResponse)
+
+  } catch (error: any) {
+    console.error('Error analyzing PR description:', error.message)
+    return {
+      comment_needed: false,
+      comment: '',
+      reasoning: 'Error occurred during AI analysis'
+    }
+  }
+}
+
+async function analyzePRCode({
+  octokit,
+  owner,
+  repo,
+  prNumber,
+  contributingContent,
+  anthropic,
+  config
+}: {
+  octokit: Octokit
+  owner: string
+  repo: string
+  prNumber: number
+  contributingContent: string
+  anthropic: Anthropic
+  config: PRAnalysisConfig
+}): Promise<{ violationCount: number; details: Array<{ file: string; line: number; message: string; severity: 'error' | 'warning' }> }> {
+  
+  const result = {
+    violationCount: 0,
+    details: [] as Array<{ file: string; line: number; message: string; severity: 'error' | 'warning' }>
+  }
+
+  try {
+    const filesResponse = await octokit.request(
+      'GET /repos/{owner}/{repo}/pulls/{pull_number}/files',
+      {
+        owner,
+        repo,
+        pull_number: prNumber,
+        per_page: 100
+      }
+    )
+
+    for (const file of filesResponse.data) {
+      if (!file.patch) continue
+
+      const changedLines = parseDiffForChangedLines(file.patch)
+      if (changedLines.length === 0) continue
+
+      const fileAnalysis = await analyzeFileChanges({
+        filename: file.filename,
+        changedLines,
+        contributingContent,
+        anthropic,
+        config
+      })
+
+      for (const violation of fileAnalysis) {
+        if (violation.comment && violation.position !== undefined) {
+          result.violationCount++
+          result.details.push({
+            file: file.filename,
+            line: violation.lineNumber || violation.position,
+            message: violation.comment,
+            severity: 'error'
+          })
+        }
+      }
+    }
+
+  } catch (error: any) {
+    console.error('Error analyzing PR code:', error.message)
+  }
+
+  return result
+}
+
+function parseDiffForChangedLines(patch: string): Array<{ line: string; position: number; lineNumber: number }> {
+  const lines = patch.split('\n')
+  const changedLines: Array<{ line: string; position: number; lineNumber: number }> = []
+  
+  let position = 0
+  let newLineNumber = 0
+  
+  for (const line of lines) {
+    if (line.startsWith('@@')) {
+      const match = line.match(/@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+      if (match) {
+        newLineNumber = parseInt(match[1]) - 1
+      }
+      continue
+    }
+    
+    position++
+    
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      newLineNumber++
+      changedLines.push({
+        line: line.substring(1),
+        position,
+        lineNumber: newLineNumber
+      })
+    } else if (!line.startsWith('-')) {
+      newLineNumber++
+    }
+  }
+  
+  return changedLines
+}
+
+async function analyzeFileChanges({
+  filename,
+  changedLines,
+  contributingContent,
+  anthropic,
+  config
+}: {
+  filename: string
+  changedLines: Array<{ line: string; position: number; lineNumber: number }>
+  contributingContent: string
+  anthropic: Anthropic
+  config: PRAnalysisConfig
+}): Promise<Array<{ position?: number; lineNumber?: number; comment?: string }>> {
+  
+  if (changedLines.length === 0) {
+    return []
+  }
+
+  try {
+    const systemPrompt = `You are a code reviewer that enforces contributing guidelines. Analyze the changed code lines and identify violations of the contributing guidelines.
+
+Only flag clear violations such as:
+- Missing required documentation
+- Violating naming conventions
+- Missing tests when required
+- Security issues mentioned in guidelines
+- Code style violations explicitly mentioned in guidelines
+
+Return a JSON array where each element has:
+- position: number (the diff position for inline comments)
+- comment: string (brief explanation of the violation)
+
+If no violations found, return an empty array.`
+
+    const codeContent = changedLines
+      .map(line => `Line ${line.lineNumber}: ${line.line}`)
+      .join('\n')
+
+    const messages: Anthropic.Messages.MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `Contributing guidelines:\n${contributingContent}`,
+            cache_control: { type: 'ephemeral' },
+          },
+          {
+            type: 'text',
+            text: `File: ${filename}
+Changed lines:
+${codeContent}`,
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: '[',
+      },
+    ]
+
+    const response = await anthropic.messages.create({
+      model: config.aiModel,
+      max_tokens: config.maxTokens,
+      system: systemPrompt,
+      messages: messages,
+    })
+
+    const aiResponse = response.content[0].type === 'text' ? response.content[0].text : ''
+    
+    try {
+      const fullResponse = `[${aiResponse}`
+      const violations = JSON.parse(fullResponse)
+      
+      return violations.map((violation: any) => ({
+        position: changedLines[violation.position]?.position,
+        lineNumber: changedLines[violation.position]?.lineNumber,
+        comment: violation.comment
+      })).filter((v: any) => v.position !== undefined)
+      
+    } catch (parseError) {
+      console.error('Error parsing AI response for file analysis:', parseError)
+      return []
+    }
+
+  } catch (error: any) {
+    console.error(`Error analyzing file ${filename}:`, error.message)
+    return []
+  }
+}

--- a/tsconfig.action.json
+++ b/tsconfig.action.json
@@ -1,0 +1,26 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "sourceMap": false,
+    "removeComments": true,
+    "noEmit": false
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
# Using Jacquez as a GitHub Action

Jacquez can now be used as a GitHub Action that runs on Pull Requests to enforce contributing guidelines. This provides a more integrated experience with red/green build status instead of just comments.

Quick Setup: 
Add this workflow to your repository at `.github/workflows/jacquez.yml`:

```yaml
name: Contributing Guidelines Check

on:
  pull_request:
    types: [opened, synchronize, reopened]

jobs:
  jacquez-check:
    name: Check Contributing Guidelines
    runs-on: ubuntu-latest
    permissions:
      contents: read
      pull-requests: write
      checks: write
    
    steps:
      - name: Checkout code
        uses: actions/checkout@v4

      - name: Run Jacquez Contributing Guidelines Check
        uses: antiwork/jacquez@main
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
          fail-on-violations: true
          skip-drafts: true
```
Required Setup
1. Anthropic API Key: Add `ANTHROPIC_API_KEY` to your repository secrets
2. Contributing Guidelines: Ensure you have a `CONTRIBUTING.md` file in your repository root, `.github/`, or `docs/` directory

How It Works

1. PR Analysis: When a PR is opened or updated, Jacquez analyzes:
   - PR description against contributing guidelines
   - Code changes for guideline violations

2. Check Run: Creates a GitHub check run with:
   - Success status if no violations found
   - Failure status if violations found
   - Detailed annotations on specific lines
   - Summary with actionable feedback

3. Build Status: The action will:
   - Pass (green) if no violations found
   - Fail (red) if violations found (when `fail-on-violations: true`)
   - Show as warning if violations found but not failing
 
Migration from Webhook Mode

If you're currently using Jacquez as a webhook/app, you can:

1. Run Both: Keep the webhook for comments and add the action for build status
2. Action Only: Use just the action for a cleaner experience
3. Hybrid: Use action for PRs and webhook for issues

the action provides the same AI-powered analysis as the webhook but integrates better with GitHub's PR workflow.
